### PR TITLE
Add/fix macOS support (closes #3)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ libeatmydata_la_SOURCES = \
   libeatmydata/libeatmydata.c
 
 noinst_HEADERS += \
+  libeatmydata/portability.h \
   libeatmydata/visibility.h
 
 libeatmydata_la_CFLAGS = \
@@ -86,11 +87,14 @@ libeatmydata_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version
 
 check_PROGRAMS += \
   libeatmydata/test/fsynctest \
-  libeatmydata/test/tst-cancel4 \
   libeatmydata/test/tst-key4 \
   libeatmydata/test/tst-invalidfd \
   libeatmydata/test/eatmydatatest \
   libeatmydata/test/eatmydatatest_largefile
+
+if HAVE_PTHREAD_BARRIERS
+  check_PROGRAMS += libeatmydata/test/tst-cancel4
+endif
 
 libeatmydata_test_tst_cancel4_LDADD= -lpthread
 

--- a/configure.ac
+++ b/configure.ac
@@ -32,14 +32,24 @@ AC_CONFIG_HEADERS([config.h])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+AC_CHECK_HEADERS_ONCE(pthread.h)
 
 AC_CHECK_SIZEOF(mode_t)
 AC_CHECK_SIZEOF(int)
+
+AC_CHECK_TYPE(pthread_barrier_t,,,[
+  #ifdef HAVE_PTHREAD_H
+  #include <pthread.h>
+  #endif
+  ])
+
+AM_CONDITIONAL(HAVE_PTHREAD_BARRIERS, [test "x$ac_cv_type_pthread_barrier_t" = xyes])
 
 AC_CHECK_DECLS(fdatasync)
 AC_CHECK_FUNCS(fdatasync)
 AC_CHECK_DECLS(sync_file_range)
 AC_CHECK_FUNCS(sync_file_range)
+AC_CHECK_FUNCS(open64)
 
 AC_CONFIG_FILES(Makefile libeatmydata.spec)
 

--- a/libeatmydata/portability.h
+++ b/libeatmydata/portability.h
@@ -1,5 +1,5 @@
 /* BEGIN LICENSE
- * Copyright (C) 2017 Yura Sorokin, Stewart Smith
+ * Copyright (C) 2017 Stewart Smith <stewart@flamingspork.com>
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
  * by the Free Software Foundation.
@@ -13,23 +13,21 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  * END LICENSE */
 
-#include "libeatmydata/portability.h"
+/**
+ * @file
+ * @brief libeatmydata portability abstraction header
+ */
 
-#include <stdio.h>
-#include <errno.h>
-#include <unistd.h>
-#include <assert.h>
+#ifndef LIBEATMYDATA_PORTABILITY_H
+#define LIBEATMYDATA_PORTABILITY_H
 
-int main()
-{
-	int fd = 42;
-	int r = fdatasync(fd);
-	assert(r == -1 && errno == EBADF);
-	r = fsync(fd);
-	assert(r == -1 && errno == EBADF);
-#ifdef HAVE_SYNC_FILE_RANGE
-	r = sync_file_range(fd, 0, 0, 0);
-	assert(r == -1 && errno == EBADF);
+#include "config.h"
+
+/*
+ * Mac OS X 10.7 doesn't declare fdatasync().
+ */
+#if defined(HAVE_FDATASYNC) && HAVE_DECL_FDATASYNC == 0
+int fdatasync(int fd);
 #endif
-	return 0;
-}
+
+#endif

--- a/libeatmydata/test/fsynctest.c
+++ b/libeatmydata/test/fsynctest.c
@@ -15,6 +15,8 @@
 
 #include "config.h"
 
+#include "libeatmydata/portability.h"
+
 #include <stdio.h>
 #include <sys/mman.h>
 #include <sys/types.h>

--- a/libeatmydata/test/tst-cancel4.c
+++ b/libeatmydata/test/tst-cancel4.c
@@ -23,11 +23,15 @@
 /* NOTE: this tests functionality beyond POSIX.  POSIX does not allow
    exit to be called more than once.  */
 
+#include "config.h"
+
 #define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#ifdef HAVE_PTHREAD_H
 #include <pthread.h>
+#endif
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/libeatmydata/test/tst-key4.c
+++ b/libeatmydata/test/tst-key4.c
@@ -16,8 +16,12 @@
    License along with the GNU C Library; if not, see
    <http://www.gnu.org/licenses/>.  */
 
+#include "config.h"
+
 #include <limits.h>
+#ifdef HAVE_PTHREAD_H
 #include <pthread.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/start_suspended.sh
+++ b/start_suspended.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Libeatmydata
+#
+# Copyright (C) 2017 Stewart Smith (stewart@flamingspork.com)
+# All rights reserved.
+#
+# Use and distribution licensed under the BSD license. See the
+# COPYING file in the root project directory for full text.
+#
+
+# A helper script to start a process in suspended state with macOS dynamic
+# library preloaded, neccessitated by bash version < 4 there which does not
+# have $BASHPID enabling an inline solution
+# (kill -s STOP $BASPID; exec foo arg) &
+
+kill -TSTP $$
+
+export DYLD_LIBRARY_PATH=libeatmydata/.libs
+export DYLD_FORCE_FLAT_NAMESPACE=1
+export DYLD_INSERT_LIBRARIES=./.libs/libeatmydata.dylib
+
+exec $@
+exit $?


### PR DESCRIPTION
This brings macOS support to the level of fully passing testsuite,
including verification with dtruss (an strace-like tool) that no *sync
syscalls are executed.

- macOS pthreads do not have pthread barriers. Add autoconf tests for
  pthread.h and pthread_barrier_t, and exclude test/tst-cancel4 from
  build if barriers are not present.
- macOS does not have open64 library function. Add autoconf test, and
  do not attempt to replace it if it does not exist.
- Extend ASSIGN_DLSYM_OR_DIE macro to print diagnostics to stderr in
  the case of dlsym failure.
- Factor out the macOS fdatasync declaration - where the function
  exists without a prototype - to a new header portability.h, fix its
  conditional compilation, include in all fdatasync-using files.
- Fix test-run.sh to work with macOS dynamic library preload scheme,
  add a new helper script start_suspended.sh to support it.