### PR TITLE
Fix issues with parallel make (Closes #10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+sudo: required
+
 addons:
   apt:
     packages:

--- a/test_run.sh
+++ b/test_run.sh
@@ -57,7 +57,7 @@ if [[ $OSTYPE == *"darwin"* ]]; then
   while [[ "$(ps -o state= -p $test_pid)" != *"T+"* ]]; do
         sleep 1
   done
-  dtruss -p $test_pid 2>> test.result.run &
+  dtruss -p $test_pid 2>> $name-test.result.run &
   dtruss_pid=$!
   kill -CONT $test_pid
   eret=wait $test_pid
@@ -65,7 +65,7 @@ if [[ $OSTYPE == *"darwin"* ]]; then
   wait $dtruss_pid
 else
   export LD_PRELOAD=./.libs/libeatmydata.so
-  strace -o test.result.run "$1" "$LIBEATMYDATA_TEST_ARGS"
+  strace -o $name-test.result.run "$1" "$LIBEATMYDATA_TEST_ARGS"
   eret=$?
 fi
 
@@ -79,9 +79,9 @@ if [[ $OSTYPE == *"darwin"* ]]; then
     SYNC_IN_TRACE="$SYNC_IN_TRACE|^fcntl\\\(.*, 0x33"
 fi
 
-grep "$SYNC_IN_TRACE" test.result.run
+grep "$SYNC_IN_TRACE" $name-test.result.run
 ret=$?
-rm test.result.run
+rm $name-test.result.run
 if [ $ret == 1 ]; then
 	exit 0;
 else


### PR DESCRIPTION
There appears to be a race condition that occurs when using multithreaded `make`. The `test_run.sh` script by default always uses the same filename, `test.result.run`, to store and check test results. Since the tests are handled by `make`, if these tests are run in parallel, this file will be repeatedly clobbered by each concurrent thread. I was able to fix this by prepending the name of the test to the names of the `test.result.run` files created by each invocation of `test_run.sh`. (e.g.: `grep "$SYNC_IN_TRACE" $name-test.result.run`)

These patches close #10, and do not affect code or compilation in any way.

(Cross-posted from [AUR](https://aur.archlinux.org/packages/libeatmydata/#comment-645888))