### PR TITLE
Usability and Mac improvements

### DIFF
--- a/eatmydata.sh.in
+++ b/eatmydata.sh.in
@@ -38,19 +38,31 @@ eatmydata_exec()
         # $cmd does not contain '/'. Look in $PATH avoiding loops with self.
         local self save_ifs path exe ok
 
-        self="`readlink -f "$0"`"
-        save_ifs="$IFS"
-        IFS=":"
         ok=""
-        for path in $PATH; do
-            exe="${path}/$cmd"
-            # Avoid loops with self
-            if [ -x "$exe" ] && [ "`readlink -f "$exe"`" != "$self" ]; then
-                ok="yes"
-                break
-            fi
-        done
-        IFS="$save_ifs"
+        exe="`which "${cmd}"`"
+        if [ -x "$exe" ] ;then
+             ok="yes"
+        else
+            case "`uname -s`" in
+                Darwin)
+                    self="`readlink "$0"`"
+                    ;;
+                *)
+                    self="`readlink -f "$0"`"
+            esac
+            save_ifs="$IFS"
+            IFS=":"
+            ok=""
+            for path in $PATH; do
+                exe="${path}/$cmd"
+                # Avoid loops with self
+                if [ -x "$exe" ] && [ "`readlink -f "$exe"`" != "$self" ]; then
+                    ok="yes"
+                    break
+                fi
+            done
+            IFS="$save_ifs"
+        fi
         if [ -n "$ok" ]; then
             cmd="$exe"
         else
@@ -60,8 +72,12 @@ eatmydata_exec()
 
     # Preload libeatmydata
     if [ `uname` = "Darwin" ]; then
-	export DYLD_FORCE_FLAT_NAMESPACE=1
-	export DYLD_INSERT_LIBRARIES="$libeatmydata"
+        export DYLD_FORCE_FLAT_NAMESPACE=1
+        if [ -n "$DYLD_INSERT_LIBRARIES" ]; then
+            export DYLD_INSERT_LIBRARIES="${libeatmydata}:${DYLD_INSERT_LIBRARIES}"
+        else
+            export DYLD_INSERT_LIBRARIES="$libeatmydata"
+        fi
     else
         if [ -n "$LD_PRELOAD" ]; then
             export LD_PRELOAD="$libeatmydata $LD_PRELOAD"


### PR DESCRIPTION
This is the PR announced in issue #13 . It's become a bit of a catch-all for a number of more or less (un)related changes:

- add support for an optional sync-on-exit (end sync). Set `EATMYDATA_END_SYNC=1` to do this only in the application launched by the user, set it `EATMYDATA_END_SYNC=2` to do it in every child process too (that does slow things down if the child processes each do only tiny bits of work).
- verbose mode: Set `EATMYDATA_VERBOSE` to print out the number of syncs and sync modes that were swallowed. Uses a simple counter without any thread-safeties because there's nothing crucial to the feature and I don't want to introduce locks in overloads of functions that have to remain signal-safe.
- Mac-related fixes, making the code build and the scripts run on 10.9 (and up, presumably).

And, a bit stupidly: a source code reformat.