### PR TITLE
Fix compile error with musl libc

### DIFF
--- a/libeatmydata/libeatmydata.c
+++ b/libeatmydata/libeatmydata.c
@@ -178,6 +178,15 @@ int LIBEATMYDATA_API open(const char* pathname, int flags, ...)
 }
 
 #if !defined(__USE_FILE_OFFSET64) && defined(HAVE_OPEN64)
+
+// Musl libc does this in `fcntl.h`:
+//
+//    #define open64 open
+//
+// It's hard to detect this situation, but we can avoid a compile failure
+// by undefining it.
+#undef open64
+
 int LIBEATMYDATA_API open64(const char* pathname, int flags, ...)
 {
 	va_list ap;


### PR DESCRIPTION
Compilation with musl otherwise fails with this error:

       CC       libeatmydata/libeatmydata_la-libeatmydata.lo
    In file included from libeatmydata/libeatmydata.c:25:
    libeatmydata/libeatmydata.c:161:22: error: redefinition of 'open'
      161 | int LIBEATMYDATA_API open64(const char* pathname, int flags, ...)
          |                      ^~~~~~
    /usr/include/fcntl.h:34:5: note: previous definition of 'open' was here
       34 | int open(const char *, int, ...);
          |     ^~~~
    make: *** [Makefile:1043: libeatmydata/libeatmydata_la-libeatmydata.lo] Error 1

Closes https://github.com/stewartsmith/libeatmydata/issues/17