### PR TITLE
Use a weak reference to pthread_testcancel

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,7 +79,7 @@ libeatmydata_la_CFLAGS = \
   $(NO_WERROR) \
 	-DBUILDING_LIBEATMYDATA
 
-libeatmydata_la_LIBADD = $(LIBDL_LIBS) -lpthread -ldl
+libeatmydata_la_LIBADD = $(LIBDL_LIBS) -ldl
 libeatmydata_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version
 
 #install-exec-hook:

--- a/libeatmydata/libeatmydata.c
+++ b/libeatmydata/libeatmydata.c
@@ -79,6 +79,7 @@ static libc_fcntl_t libc_fcntl= NULL;
         libc_##name = (libc_##name##_##t)(intptr_t)dlsym(RTLD_NEXT, #name);			\
 						   dlerror();
 
+#pragma weak pthread_testcancel
 
 int LIBEATMYDATA_API msync(void *addr, size_t length, int flags);
 static int initing = 0;
@@ -130,7 +131,8 @@ static int eatmydata_is_hungry(void)
 int LIBEATMYDATA_API fsync(int fd)
 {
 	if (eatmydata_is_hungry()) {
-		pthread_testcancel();
+		if (pthread_testcancel)
+			pthread_testcancel();
 		if (fcntl(fd, F_GETFD) == -1) {
 		  return -1;
 		}
@@ -208,7 +210,8 @@ int LIBEATMYDATA_API open64(const char* pathname, int flags, ...)
 int LIBEATMYDATA_API fdatasync(int fd)
 {
 	if (eatmydata_is_hungry()) {
-		pthread_testcancel();
+		if (pthread_testcancel)
+			pthread_testcancel();
 		if (fcntl(fd, F_GETFD) == -1) {
 		  return -1;
 		}
@@ -222,7 +225,8 @@ int LIBEATMYDATA_API fdatasync(int fd)
 int LIBEATMYDATA_API msync(void *addr, size_t length, int flags)
 {
 	if (eatmydata_is_hungry()) {
-		pthread_testcancel();
+		if (pthread_testcancel)
+			pthread_testcancel();
 		errno= 0;
 		return 0;
 	}
@@ -235,7 +239,8 @@ int LIBEATMYDATA_API sync_file_range(int fd, off64_t offset, off64_t nbytes,
 				     unsigned int flags)
 {
 	if (eatmydata_is_hungry()) {
-		pthread_testcancel();
+		if (pthread_testcancel)
+			pthread_testcancel();
 		if (fcntl(fd, F_GETFD) == -1) {
 		  return -1;
 		}


### PR DESCRIPTION
so that it's called only if the program itself pulls libpthread

This avoids an hard link on pthread.

libeatmydata is linked against libpthread. This thus pulls libpthread
in all processes run under eatmydata. It happens that having
libpthread in a process makes pthread_mutex_lock() and all such basic
performance-sensitive operations much heavier (since they then have to
deal with potential multithreading). This avoids that by using a weak reference
to pthread_testcancel, so that pthread_testcancel is called only if the program
itself pulls libpthread.

Author: Samuel Thibault <sthibault@debian.org>
Bug-LP: https://bugs.launchpad.net/libeatmydata/+bug/1556410
Bug-Debian: https://bugs.debian.org/816144
Signed-off-by: Mattia Rizzolo <mattia@mapreri.org>