### PR TITLE
Add gitattributes for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/m4/* linguist-vendored


### PR DESCRIPTION
Teach GitHub Linguist that the `m4` directory is vendored code.

This should make GitHub language classification more helpful.

Before:

* M4 70.5%
* C 22.6%
* Shell 4.2%
* Makefile 2.7%

After:

* C 74.4%
* Shell 13.9%
* Makefile 8.9%
* M4 2.8%